### PR TITLE
make deric/mesos a requirement and make sure mesos is installed

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -47,21 +47,4 @@ class marathon::config {
       service => $marathon::service,
     }
   }
-
-  # Create directory just in case Mesos is not installed on system
-  # Using mkdir -p to both create the entire path AND avoid managing
-  # the directory resource because Mesos module should do so.
-  exec{'create_zk_directory':
-    command => "/bin/mkdir -p ${marathon::zk_conf_dir}",
-    creates => $marathon::zk_conf_dir,
-  }
-  ->
-  # Marathon relies on this file
-  file { "${marathon::zk_conf_dir}/${marathon::zk_conf_file}":
-    ensure  => 'present',
-    content => $marathon::zookeeper,
-    owner   => $marathon::owner,
-    group   => $marathon::group,
-  }
-
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -40,6 +40,8 @@ class marathon (
     default  => $version,
   }
 
+  require ::mesos::master
+
   anchor {'marathon::begin': } ->
   class {'::marathon::repo': } ->
   class {'::marathon::install': } ->

--- a/metadata.json
+++ b/metadata.json
@@ -15,6 +15,10 @@
     {
       "name": "puppetlabs/apt",
       "version_requirement": ">= 1.0.0"
+    },
+    {
+      "name": "deric/mesos",
+      "version_requirement": ">= 0.6.2"
     }
   ],
   "requirements": [


### PR DESCRIPTION
I couldn't come up with a scenario where it would make sense to try to install Marathon without Mesos so I added a requirement on the deric/mesos module and a require statementn in the init.pp to make sure Mesos is installed. I also removed the explicit managment of /etc/mesos/zk under the assumption that a properly configured mesos::master will have that file.

Be happy to discuss further.
